### PR TITLE
Fix check for Angular 2 annotations.

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1126,7 +1126,7 @@ class _AnnotationProcessorMixin {
   bool _isAngularAnnotation(ast.Annotation node, String name) {
     if (node.element is ConstructorElement) {
       ClassElement clazz = node.element.enclosingElement;
-      return clazz.library.name == 'angular2.src.core.metadata' &&
+      return clazz.library.source.uri.path.contains('angular2') &&
           clazz.name == name;
     }
     return false;

--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -1126,7 +1126,8 @@ class _AnnotationProcessorMixin {
   bool _isAngularAnnotation(ast.Annotation node, String name) {
     if (node.element is ConstructorElement) {
       ClassElement clazz = node.element.enclosingElement;
-      return clazz.library.source.uri.path.contains('angular2') &&
+      return clazz.library.source.uri.path
+              .endsWith('angular2/src/core/metadata.dart') &&
           clazz.name == name;
     }
     return false;

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -160,13 +160,13 @@ class AbstractAngularTest {
         r'''
 library angular2;
 
-export 'async.dart';
-export 'metadata.dart';
-export 'ng_if.dart';
-export 'ng_for.dart';
+export 'src/core/async.dart';
+export 'src/core/metadata.dart';
+export 'src/core/ng_if.dart';
+export 'src/core/ng_for.dart';
 ''');
     newSource(
-        '/angular2/metadata.dart',
+        '/angular2/src/core/metadata.dart',
         r'''
 import 'dart:async';
 
@@ -244,7 +244,7 @@ class Output {
 }
 ''');
     newSource(
-        '/angular2/async.dart',
+        '/angular2/src/core/async.dart',
         r'''
 import 'dart:async';
 
@@ -279,7 +279,7 @@ class EventEmitter<T> extends Stream<T> {
 }
 ''');
     newSource(
-        '/angular2/ng_if.dart',
+        '/angular2/src/core/ng_if.dart',
         r'''
 import 'metadata.dart';
 
@@ -289,7 +289,7 @@ class NgIf {
 }
 ''');
     newSource(
-        '/angular2/ng_for.dart',
+        '/angular2/src/core/ng_for.dart',
         r'''
 import 'metadata.dart';
 

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -168,8 +168,6 @@ export 'ng_for.dart';
     newSource(
         '/angular2/metadata.dart',
         r'''
-library angular2.src.core.metadata;
-
 import 'dart:async';
 
 abstract class Directive {
@@ -248,7 +246,6 @@ class Output {
     newSource(
         '/angular2/async.dart',
         r'''
-library angular2.core.facade.async;
 import 'dart:async';
 
 class EventEmitter<T> extends Stream<T> {
@@ -284,7 +281,6 @@ class EventEmitter<T> extends Stream<T> {
     newSource(
         '/angular2/ng_if.dart',
         r'''
-library angular2.ng_if;
 import 'metadata.dart';
 
 @Directive(selector: "[ngIf]", inputs: const ["ngIf"])
@@ -295,7 +291,6 @@ class NgIf {
     newSource(
         '/angular2/ng_for.dart',
         r'''
-library angular2.ng_for;
 import 'metadata.dart';
 
 @Directive(


### PR DESCRIPTION
Check whether an annotaion belongs to Angular 2 using the library source path. The library names for Angular 2 sources are empty because there are no library declarations in Angular 2.