### PR TITLE
Monitor the correct stream of invalidations to keep views in sync

### DIFF
--- a/analyzer_plugin/lib/src/angular_work_manager.dart
+++ b/analyzer_plugin/lib/src/angular_work_manager.dart
@@ -41,7 +41,7 @@ class AngularWorkManager implements WorkManager {
    * Initialize a newly created manager.
    */
   AngularWorkManager(this.context) {
-    analysisCache.onResultInvalidated.listen((InvalidatedResult result) {
+    context.onResultInvalidated.listen((InvalidatedResult result) {
       if (result.descriptor == VIEWS_WITH_HTML_TEMPLATES) {
         List<View> views = result.value;
         for (View view in views) {


### PR DESCRIPTION
Note that this error was also in the analyzer source and I have a patch open for that: https://codereview.chromium.org/2454233003/

With both this and the patch in the analyzer, html template errors are kept in sync when you update dart files.