### PR TITLE
Detect missing html template files in components

### DIFF
--- a/analyzer_plugin/lib/src/tasks.dart
+++ b/analyzer_plugin/lib/src/tasks.dart
@@ -679,7 +679,13 @@ class BuildUnitViewsTask extends SourceBasedAnalysisTask
         SourceFactory sourceFactory = context.sourceFactory;
         templateUriSource =
             sourceFactory.resolveUri(target.source, templateUrl);
-        // TODO: report a warning if it cannot be resolved.
+
+	if (!templateUriSource.exists()) {
+          errorReporter.reportErrorForNode(
+              AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST,
+              templateUrlExpression);
+        }
+
         templateUrlRange = new SourceRange(
             templateUrlExpression.offset, templateUrlExpression.length);
       }

--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -28,6 +28,13 @@ class AngularWarningCode extends ErrorCode {
           'CANNOT_PARSE_SELECTOR', 'Cannot parse the given selector');
 
   /**
+   * An error code indicating that a template points to a missing html file
+   */
+  static const AngularWarningCode REFERENCED_HTML_FILE_DOESNT_EXIST =
+      const AngularWarningCode( 'REFERENCED_HTML_FILE_DOESNT_EXIST',
+           'The referenced HTML file doesn\'t exist');
+
+  /**
    * An error code indicating that the component has @View annotation,
    * but not @Component annotation.
    */

--- a/analyzer_plugin/test/abstract_angular.dart
+++ b/analyzer_plugin/test/abstract_angular.dart
@@ -301,6 +301,20 @@ class NgFor {
 }
 ''');
   }
+
+  /**
+   * Assert that the [errCode] is reported for [code], highlighting the [snippet].
+   */
+  void assertErrorInCodeAtPosition(
+      ErrorCode errCode, String code, String snippet) {
+    int snippetIndex = code.indexOf(snippet);
+    expect(snippetIndex, greaterThan(-1),
+        reason: 'Error in test: snippet ${snippet} not part of code ${code}');
+    errorListener.assertErrorsWithCodes(<ErrorCode>[errCode]);
+    AnalysisError error = errorListener.errors.single;
+    expect(error.offset, snippetIndex);
+    expect(errorListener.errors.single.length, snippet.length);
+  }
 }
 
 /**

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -630,10 +630,11 @@ class ComponentA {
         r'''
 import '/angular2/angular2.dart';
 
-@Component(selector: 'aaa', template: 'AAA', templateUrl: 'AAA')
+@Component(selector: 'aaa', template: 'AAA', templateUrl: 'a.html')
 class ComponentA {
 }
 ''');
+    newSource('/a.html', '');
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
     computeResult(target, VIEWS);
     expect(task, new isInstanceOf<BuildUnitViewsTask>());
@@ -660,6 +661,29 @@ class ComponentA {
     fillErrorListener(VIEWS_ERRORS);
     errorListener.assertErrorsWithCodes(
         <ErrorCode>[AngularWarningCode.NO_TEMPLATE_URL_OR_TEMPLATE_DEFINED]);
+  }
+
+  void test_hasError_missingHtmlFile() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'my-component', templateUrl: 'my-template.html')
+class MyComponent {}
+''';
+    Source dartSource = newSource('/test.dart', code);
+    LibrarySpecificUnit target =
+        new LibrarySpecificUnit(dartSource, dartSource);
+    computeResult(target, VIEWS);
+    expect(task, new isInstanceOf<BuildUnitViewsTask>());
+    // validate
+    fillErrorListener(VIEWS_ERRORS);
+    errorListener.assertErrorsWithCodes(<ErrorCode>[
+            AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST]);
+    {
+      AnalysisError error = errorListener.errors.single;
+      expect(error.offset, code.indexOf("'my-template.html'"));
+      expect(errorListener.errors.single.length, "'my-template.html'".length);
+    }
   }
 
   void test_templateExternal() {

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -667,7 +667,7 @@ class ComponentA {
     String code = r'''
 import '/angular2/angular2.dart';
 
-@Component(selector: 'my-component', templateUrl: 'my-template.html')
+@Component(selector: 'my-component', templateUrl: 'missing-template.html')
 class MyComponent {}
 ''';
     Source dartSource = newSource('/test.dart', code);
@@ -677,13 +677,10 @@ class MyComponent {}
     expect(task, new isInstanceOf<BuildUnitViewsTask>());
     // validate
     fillErrorListener(VIEWS_ERRORS);
-    errorListener.assertErrorsWithCodes(<ErrorCode>[
-            AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST]);
-    {
-      AnalysisError error = errorListener.errors.single;
-      expect(error.offset, code.indexOf("'my-template.html'"));
-      expect(errorListener.errors.single.length, "'my-template.html'".length);
-    }
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.REFERENCED_HTML_FILE_DOESNT_EXIST,
+        code,
+        "'missing-template.html'");
   }
 
   void test_templateExternal() {
@@ -1051,13 +1048,8 @@ class ComponentA {
     expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
     // validate
     fillErrorListener(DART_TEMPLATES_ERRORS);
-    errorListener
-        .assertErrorsWithCodes(<ErrorCode>[AngularWarningCode.UNRESOLVED_TAG]);
-    {
-      AnalysisError error = errorListener.errors.single;
-      expect(error.offset, code.indexOf('unresolved-tag'));
-      expect(errorListener.errors.single.length, 'unresolved-tag'.length);
-    }
+    assertErrorInCodeAtPosition(
+        AngularWarningCode.UNRESOLVED_TAG, code, 'unresolved-tag');
   }
 
   void test_htmlParsing_hasError() {


### PR DESCRIPTION
Plus tests.

Previous approach was overly complicated, thanks to Konstantin Shcheglov
for suggesting this much much simpler one.

A prior test with an invalid html template was now throwing this new error in addition to what it expected. In the name of "exactly one test should fail" I set that test to have a valid file.