### PR TITLE
Template errors beyond first tag

### DIFF
--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -96,7 +96,10 @@ class DartTemplateResolver {
       html.HtmlParser parser = new html.HtmlParser(fragmentText,
           generateSpans: true, lowercaseAttrName: false);
       parser.compatMode = 'quirks';
-      document = parser.parseFragment('template');
+
+      // Don't parse a template, but parse as a document. That way there will
+      // be a single first element with all contents.
+      document = parser.parse();
       _addParseErrors(parser);
     }
     // Create and resolve Template.
@@ -113,6 +116,13 @@ class DartTemplateResolver {
   void _addParseErrors(html.HtmlParser parser) {
     List<html.ParseError> parseErrors = parser.errors;
     for (html.ParseError parseError in parseErrors) {
+      // We parse this as a full document rather than as a template so
+      // that everything is in the first document element. But then we
+      // get these errors which don't apply -- suppress them.
+      if (parseError.errorCode == 'expected-doctype-but-got-start-tag'
+          || parseError.errorCode == 'expected-doctype-but-got-chars') {
+        continue;
+      }
       SourceSpan span = parseError.span;
       _reportErrorForSpan(
           span, HtmlErrorCode.PARSE_ERROR, [parseError.message]);

--- a/analyzer_plugin/lib/src/resolver.dart
+++ b/analyzer_plugin/lib/src/resolver.dart
@@ -97,8 +97,8 @@ class DartTemplateResolver {
           generateSpans: true, lowercaseAttrName: false);
       parser.compatMode = 'quirks';
 
-      // Don't parse a template, but parse as a document. That way there will
-      // be a single first element with all contents.
+      // Don't parse as a fragment, but parse as a document. That way there
+      // will be a single first element with all contents.
       document = parser.parse();
       _addParseErrors(parser);
     }
@@ -119,8 +119,8 @@ class DartTemplateResolver {
       // We parse this as a full document rather than as a template so
       // that everything is in the first document element. But then we
       // get these errors which don't apply -- suppress them.
-      if (parseError.errorCode == 'expected-doctype-but-got-start-tag'
-          || parseError.errorCode == 'expected-doctype-but-got-chars') {
+      if (parseError.errorCode == 'expected-doctype-but-got-start-tag' ||
+          parseError.errorCode == 'expected-doctype-but-got-chars') {
         continue;
       }
       SourceSpan span = parseError.span;

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -1051,27 +1051,6 @@ class MyComponent {
         StaticWarningCode.UNDEFINED_IDENTIFIER, code, 'noSuchName');
   }
 
-  void
-      test_hasError_expression_UndefinedIdentifier_OutsideFirstHtmlTagTemplate() {
-    String templateCode = '<h1></h1>{{noSuchName}}';
-    String code = r'''
-import '/angular2/angular2.dart';
-
-@Component(selector: 'my-component', templateUrl: 'template.html')
-class MyComponent {
-}
-''';
-    Source source = newSource('/test.dart', code);
-    newSource('/template.html', templateCode);
-    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
-    computeResult(target, DART_TEMPLATES);
-    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
-    // has errors
-    fillErrorListener(DART_TEMPLATES_ERRORS);
-    assertErrorInCodeAtPosition(
-        StaticWarningCode.UNDEFINED_IDENTIFIER, templateCode, 'noSuchName');
-  }
-
   void test_hasError_UnresolvedTag() {
     String code = r'''
 import '/angular2/angular2.dart';

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -1033,6 +1033,45 @@ class UserPanel {
         .assertErrorsWithCodes([StaticWarningCode.UNDEFINED_IDENTIFIER]);
   }
 
+  void test_hasError_expression_UndefinedIdentifier_OutsideFirstHtmlTag() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'my-component', template: '<h1></h1>{{noSuchName}}')
+class MyComponent {
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // has errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.UNDEFINED_IDENTIFIER, code, 'noSuchName');
+  }
+
+  void
+      test_hasError_expression_UndefinedIdentifier_OutsideFirstHtmlTagTemplate() {
+    String templateCode = '<h1></h1>{{noSuchName}}';
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'my-component', templateUrl: 'template.html')
+class MyComponent {
+}
+''';
+    Source source = newSource('/test.dart', code);
+    newSource('/template.html', templateCode);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // has errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    assertErrorInCodeAtPosition(
+        StaticWarningCode.UNDEFINED_IDENTIFIER, templateCode, 'noSuchName');
+  }
+
   void test_hasError_UnresolvedTag() {
     String code = r'''
 import '/angular2/angular2.dart';

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -1041,6 +1041,7 @@ import '/angular2/angular2.dart';
 class MyComponent {
 }
 ''';
+
     Source source = newSource('/test.dart', code);
     LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
     computeResult(target, DART_TEMPLATES);


### PR DESCRIPTION
Noticed that the error wasn't occurring inside full html templates, saw
the difference in how the dart analyzer handles html parsing and applied
it here. Saves us from getting highly involved in the dart html parser
API when the root isn't simple.