### PR TITLE
Catch more types of unmatched mustaches

### DIFF
--- a/analyzer_plugin/lib/tasks.dart
+++ b/analyzer_plugin/lib/tasks.dart
@@ -96,6 +96,12 @@ class AngularWarningCode extends ErrorCode {
           'UNTERMINATED_MUSTACHE', 'Unterminated mustache');
 
   /**
+   * An error code indicating that a mustache ending was found unopened
+   */
+  static const AngularWarningCode UNOPENED_MUSTACHE = const AngularWarningCode(
+      'UNOPENED_MUSTACHE', 'Mustache terminator with no opening');
+
+  /**
    * Initialize a newly created error code to have the given [name].
    * The message associated with the error will be created from the given
    * [message] template. The correction associated with the error will be

--- a/analyzer_plugin/test/tasks_test.dart
+++ b/analyzer_plugin/test/tasks_test.dart
@@ -1284,6 +1284,74 @@ class TextPanel {
         .assertErrorsWithCodes([AngularWarningCode.UNTERMINATED_MUSTACHE]);
   }
 
+  void test_textExpression_hasError_UnopenedMustache() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'text-panel', template: r"<div> text}} </div>")
+class TextPanel {
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // validate
+    List<Template> templates = outputs[DART_TEMPLATES];
+    expect(templates, hasLength(1));
+    // has errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    errorListener.assertErrorsWithCodes([AngularWarningCode.UNOPENED_MUSTACHE]);
+  }
+
+  void test_textExpression_hasError_DoubleOpenedMustache() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'text-panel', template: r"<div> {{text {{ text}} </div>")
+class TextPanel {
+  String text;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // validate
+    List<Template> templates = outputs[DART_TEMPLATES];
+    expect(templates, hasLength(1));
+    // has errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    errorListener
+        .assertErrorsWithCodes([AngularWarningCode.UNTERMINATED_MUSTACHE]);
+  }
+
+  void test_textExpression_hasError_MultipleUnclosedMustaches() {
+    String code = r'''
+import '/angular2/angular2.dart';
+
+@Component(selector: 'text-panel', template: r"<div> {{open {{open {{text}} close}} close}} </div>")
+class TextPanel {
+  String text;
+}
+''';
+    Source source = newSource('/test.dart', code);
+    LibrarySpecificUnit target = new LibrarySpecificUnit(source, source);
+    computeResult(target, DART_TEMPLATES);
+    expect(task, new isInstanceOf<ResolveDartTemplatesTask>());
+    // validate
+    List<Template> templates = outputs[DART_TEMPLATES];
+    expect(templates, hasLength(1));
+    // has errors
+    fillErrorListener(DART_TEMPLATES_ERRORS);
+    errorListener.assertErrorsWithCodes([
+      AngularWarningCode.UNTERMINATED_MUSTACHE,
+      AngularWarningCode.UNTERMINATED_MUSTACHE,
+      AngularWarningCode.UNOPENED_MUSTACHE,
+      AngularWarningCode.UNOPENED_MUSTACHE
+    ]);
+  }
+
   void test_textExpression_OK() {
     String code = r'''
 import '/angular2/angular2.dart';


### PR DESCRIPTION
Catch mustaches that weren't opened, and mustaches that open before
another one closes. Also change 'lastEnd' + 'offset' to 'textOffset' and
'fileOffset' since that is clearer.

Also catch more than one mustache error per text snippet in the html.

Plus tests.